### PR TITLE
[bug/26] response message was not triggered after initial search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,13 +30,17 @@ const App: React.FC = () => {
 		if (movieData && movieData.length > 0) {
 			setAreMovies(true);
 		}
+		if (searchTerm.length === 0 || movieData === undefined) {
+			setAreMovies(false);
+		}
+		console.log(movieData);
 	}, [movieData]);
 
 	const handleResponseMessage = () => {
 		if (isError) {
 			return 'An Error occured during your movie search';
 		}
-		if (hasSearched && !areMovies) {
+		if (!areMovies) {
 			return 'No movies found';
 		}
 		return '';
@@ -52,10 +56,9 @@ const App: React.FC = () => {
 					setSearchTerm={setSearchTerm} // Pass setSearchTerm to SearchBar
 				/>
 			</Center>
-			{(hasSearched && !areMovies && !isLoading) ||
-				(isError && (
-					<ActionResponse responseMessage={handleResponseMessage()} />
-				))}
+			{(hasSearched && !areMovies && !isLoading) || isError ? (
+				<ActionResponse responseMessage={handleResponseMessage()} />
+			) : null}
 			{hasSearched && areMovies && <MovieList movies={movieData as Movie[]} />}
 		</Box>
 	);


### PR DESCRIPTION
- `ActionResponse` message is now consistently showing if there is an error or no movies are found.
- `areMovies` returns false if `movieData` is undefined, or if the user search input is an empty string. 
