### PR TITLE
[bug/35] Inconsistent image poster sizes

### DIFF
--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image } from '@chakra-ui/react';
+import { Image, useBreakpointValue } from '@chakra-ui/react';
 import { MovieSearch } from '../lib/types/movies';
 
 interface MovieCardProps {
@@ -8,12 +8,26 @@ interface MovieCardProps {
 }
 
 const MovieCard: React.FC<MovieCardProps> = ({ movie, onMovieClick }) => {
+	const imageHeight = useBreakpointValue({
+		base: '200px',
+		md: '250px',
+		lg: '300px',
+		xl: '400px',
+	});
+	const imageWidth = useBreakpointValue({
+		base: '135px',
+		md: '170px',
+		lg: '200px',
+		xl: '235px',
+	});
 	return (
 		<Image
 			boxShadow='xl'
 			role='button'
 			borderRadius='lg'
 			transition='transform 0.3s'
+			h={imageHeight}
+			w={imageWidth}
 			_hover={{
 				outline: 'none',
 				boxShadow: '2xl',

--- a/src/components/MovieDetailsCard.tsx
+++ b/src/components/MovieDetailsCard.tsx
@@ -62,7 +62,7 @@ const MovieDetailsCard: React.FC<MovieDetailsCardProps> = ({
 					<Text opacity='.7' pr='10px'>
 						IMDb RATING
 					</Text>
-					<StarIcon />
+					<StarIcon color='#F5C518' />
 					<Text pl='10px'>{movieDetails.imdbRating}</Text>
 					<Text opacity='.7' pr='10px'>
 						/10

--- a/src/containers/MovieList.tsx
+++ b/src/containers/MovieList.tsx
@@ -15,8 +15,9 @@ const MovieList: React.FC<MovieListProps> = ({ movies, onMovieClick }) => {
 	return (
 		<Box>
 			<SimpleGrid
-				columns={[2, 2, 3, 4, 5]}
+				columns={[2, 3, 4, 4, 5]}
 				spacing={{ base: 4, md: 10 }}
+				justifyItems='center'
 				p={{ base: 4, md: 10 }}
 			>
 				{movies.map((movie) => (


### PR DESCRIPTION
- poster image h and w are now sized using breakpoints.
- movie list grid is now centred.
- star icon is `MovieDetailsCard` is now yellow.