### PR TITLE
[bug/38] Fix display of error message

### DIFF
--- a/src/components/ActionResponse.tsx
+++ b/src/components/ActionResponse.tsx
@@ -15,25 +15,30 @@ const ActionResponse: React.FC<ActionResponseProps> = ({ responseMessage }) => {
 			backgroundColor='rgba(0,0,0,0.2)'
 		>
 			<Box
-				display='block'
+				display='flex'
 				position='fixed'
-				top='25%'
-				left='25%'
-				width='100%'
-				height='100%'
+				top='0'
+				left='0'
+				width='100vw'
+				height='100vh'
+				alignItems='center'
+				justifyContent='center'
 				z-index='1'
 			>
 				<Alert
 					status='error'
 					width='60%'
+					height='20%'
 					display='flex'
 					flexDirection={{ base: 'column', md: 'row' }}
 					justifyContent='center'
 					borderRadius='lg'
 					border='solid'
 					borderColor='#e53e3e'
+					bgColor='rgb(255 139 139 / 95%)'
+					z-index='2'
 				>
-					<AlertIcon />
+					<AlertIcon color='none' />
 					<AlertTitle>{responseMessage}</AlertTitle>
 				</Alert>
 			</Box>


### PR DESCRIPTION
- Error message is now displaying an appropriate colour for both light and dark mode.
- `Alert` is now in a flex box.  